### PR TITLE
Fix: Properly initialize logger

### DIFF
--- a/src/morphology_workflows/tasks/cli.py
+++ b/src/morphology_workflows/tasks/cli.py
@@ -286,6 +286,12 @@ def main(arguments=None):
     logging.getLogger("luigi-interface").propagate = False
     luigi_config = luigi.configuration.get_config()
     logging_conf = luigi_config.get("core", "logging_conf_file", None)
+    if logging_conf is not None and not Path(logging_conf).exists():
+        L.warning(
+            "The core->logging_conf_file entry is not a valid path so the default logging "
+            "configuration is taken."
+        )
+        logging_conf = None
     if logging_conf is None:
         logging_conf = str(_TEMPLATES / "logging.conf")
         luigi_config.set("core", "logging_conf_file", logging_conf)

--- a/src/morphology_workflows/tasks/cli.py
+++ b/src/morphology_workflows/tasks/cli.py
@@ -285,11 +285,11 @@ def main(arguments=None):
     logging.getLogger("luigi").propagate = False
     logging.getLogger("luigi-interface").propagate = False
     luigi_config = luigi.configuration.get_config()
-    logging_conf = luigi_config.get("core", "logging_conf_file", "logging.conf")
-    if Path(logging_conf).exists():
-        logging.config.fileConfig(str(logging_conf), disable_existing_loggers=False)
-    else:
-        logging.config.fileConfig(str(_TEMPLATES / "logging.conf"), disable_existing_loggers=False)
+    logging_conf = luigi_config.get("core", "logging_conf_file", None)
+    if logging_conf is None:
+        logging_conf = str(_TEMPLATES / "logging.conf")
+        luigi_config.set("core", "logging_conf_file", logging_conf)
+    logging.config.fileConfig(str(logging_conf), disable_existing_loggers=False)
 
     # Parse arguments
     if arguments is None:


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
<!-- The title should have the following form: 'Type: Subject' with 'type' in [Build,Chore,CI,Reprecate,Docs,Feat,Fix,Perf,Refactor,Revert,Style,Test] -->

### Description
When no `logging_conf_file` entry is given in the `luigi.cfg` file, the loggers may not be properly initialized which can result in duplicated entries.
