### PR TITLE
Feat: Smooth diameters for all population

### DIFF
--- a/src/morphology_workflows/repair.py
+++ b/src/morphology_workflows/repair.py
@@ -9,8 +9,8 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from data_validation_framework.result import ValidationResult
-from diameter_synthesis.main import diametrize_single_neuron
+from data_validation_framework.result import ValidationResult, ValidationResultSet
+from diameter_synthesis.main import build_model, build_diameters
 from matplotlib.backends.backend_pdf import PdfPages
 from morph_tool.converter import convert
 from morph_tool.exceptions import MorphToolException
@@ -190,13 +190,30 @@ def plot_repair(row, data_dir, with_plotly=True):
     return ValidationResult(is_valid=True, plot_repair_path=plot_path)
 
 
-def smooth_diameters(row, data_dir):
+def smooth_diameters(df, data_dir, neurite_types=None):
     """Smooth diameters using diameter-synthesis simpler algorithm."""
-    morph = Morphology(row.morph_path)
-    diametrize_single_neuron(morph)
-    morph_path = data_dir / Path(row.morph_path).name
-    write_neuron(morph, morph_path)
-    return ValidationResult(is_valid=True, morph_path=morph_path)
+    if neurite_types is None:
+        neurite_types = ["basal_dendrite", "apical_dendrite"]
+
+    config = {"models": ["simpler"], "neurite_types": neurite_types, "seed": 42}
+
+    if "with_diameters" not in df.columns:
+        df["with_diameters"] = True
+
+    morphologies = [
+        load_morphology(df.loc[gid, "morph_path"])
+        for gid in df.index
+        if df.loc[gid, "with_diameters"]
+    ]
+    model_params = build_model(morphologies, config)
+
+    for gid in df.index:
+        morph = Morphology(df.loc[gid, "morph_path"])
+        build_diameters(morph, neurite_types, model_params, diam_params=config)
+        morph_path = data_dir / Path(df.loc[gid, "morph_path"]).name
+        df.loc[gid, "morph_path"] = morph_path
+        write_neuron(morph, morph_path)
+    return ValidationResultSet(data=df, output_columns={"morph_path": None})
 
 
 def plot_smooth_diameters(row, data_dir, shift=200):

--- a/src/morphology_workflows/repair.py
+++ b/src/morphology_workflows/repair.py
@@ -9,8 +9,10 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from data_validation_framework.result import ValidationResult, ValidationResultSet
-from diameter_synthesis.main import build_model, build_diameters
+from data_validation_framework.result import ValidationResult
+from data_validation_framework.result import ValidationResultSet
+from diameter_synthesis.main import build_diameters
+from diameter_synthesis.main import build_model
 from matplotlib.backends.backend_pdf import PdfPages
 from morph_tool.converter import convert
 from morph_tool.exceptions import MorphToolException
@@ -190,12 +192,12 @@ def plot_repair(row, data_dir, with_plotly=True):
     return ValidationResult(is_valid=True, plot_repair_path=plot_path)
 
 
-def smooth_diameters(df, data_dir, neurite_types=None):
+def smooth_diameters(df, data_dir, neurite_types=None, seed=42):
     """Smooth diameters using diameter-synthesis simpler algorithm."""
     if neurite_types is None:
         neurite_types = ["basal_dendrite", "apical_dendrite"]
 
-    config = {"models": ["simpler"], "neurite_types": neurite_types, "seed": 42}
+    config = {"models": ["simpler"], "neurite_types": neurite_types, "seed": seed}
 
     if "with_diameters" not in df.columns:
         df["with_diameters"] = True

--- a/src/morphology_workflows/tasks/repair.py
+++ b/src/morphology_workflows/tasks/repair.py
@@ -235,7 +235,7 @@ class PlotRepair(StrIndexMixin, SkippableMixin(), ElementValidationTask):
         }
 
 
-class SmoothDiameters(StrIndexMixin, SkippableMixin(True), ElementValidationTask):
+class SmoothDiameters(StrIndexMixin, SkippableMixin(True), SetValidationTask):
     """Smooth diameters with :mod:`diameter_synthesis`.
 
     We use actual diameters to learn a diameter model used to diametrize the morphology.
@@ -243,7 +243,13 @@ class SmoothDiameters(StrIndexMixin, SkippableMixin(True), ElementValidationTask
     By default, this task is skipped.
     """
 
+    neurite_types = luigi.OptionalListParameter(
+        default=None, description=":list: List of neurite_types to smooth"
+    )
     output_columns = {"morph_path": None}
+
+    def kwargs(self):
+        return {"neurite_types": self.neurite_types}
 
     validation_function = smooth_diameters
 

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
     pylint -j {env:PYLINT_NPROCS:1} {[base]files}
 
 [testenv:format]
-basepython = python3.8
+basepython = python3
 skip_install = true
 deps =
     codespell


### PR DESCRIPTION
We improve the SmoothDiameters task by considering entire population to learn diameter model. In addition, it uses a subset of it, if the flag with_diameters is used. 