### PR TITLE
Feat: Make the RepairNeurites step skippable

### DIFF
--- a/src/morphology_workflows/tasks/repair.py
+++ b/src/morphology_workflows/tasks/repair.py
@@ -41,7 +41,7 @@ class CollectAnnotated(StrIndexMixin, ElementValidationTask):
     validation_function = collect
 
 
-class FixZeroDiameters(StrIndexMixin, ElementValidationTask):
+class FixZeroDiameters(StrIndexMixin, SkippableMixin(), ElementValidationTask):
     """Fix zero diameters.
 
     This task applies a fix on zero diameters on dendrites, by calling
@@ -56,7 +56,7 @@ class FixZeroDiameters(StrIndexMixin, ElementValidationTask):
         return {CollectAnnotated: {"morph_path": "morph_path"}}
 
 
-class Unravel(StrIndexMixin, ElementValidationTask):
+class Unravel(StrIndexMixin, SkippableMixin(), ElementValidationTask):
     """Unravel morphologies.
 
     In-vitro morphologies produce recostruction with too much tortuosity, which is corrected for
@@ -89,7 +89,7 @@ class Unravel(StrIndexMixin, ElementValidationTask):
         }
 
 
-class RepairNeurites(StrIndexMixin, ElementValidationTask):
+class RepairNeurites(StrIndexMixin, SkippableMixin(), ElementValidationTask):
     """RepairNeurites morphologies.
 
     Using the cut leaves, we recreate missing branches using neuror.main.repair.


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
<!-- The title should have the following form: 'Type: Subject' with 'type' in [Build,Chore,CI,Reprecate,Docs,Feat,Fix,Perf,Refactor,Revert,Style,Test] -->

### Description
Some users want to skip the `FixZeroDiameters`, `Unravel` and/or `RepairNeurites` steps so let's allow it.

### Checklist
<!-- Go over following points. Check them with an `x` if they do apply (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once). -->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- [ ] Please include: `Fixes: #<issue number>` in the description if it solves an existing issue
	  (which must include a complete example of the issue).
	- [ ] Please include tests that fail with the `main` branch and pass with the provided fix.
- [x] A new feature implementation or update an existing feature
	- [ ] Please include: `Fixes: #<issue number>` in the description if it solves an existing issue
	  (which must include a complete example of the feature).
	- [ ] Please include tests that cover every lines of the new/updated feature.
	- [ ] Please update the documentation to describe the new/updated feature.

<!-- **Have a nice day!** -->
